### PR TITLE
Feature: Add support for formatting endless methods

### DIFF
--- a/lib/rufo/formatter.rb
+++ b/lib/rufo/formatter.rb
@@ -1996,6 +1996,13 @@ class Rufo::Formatter
     #   [:@ident, "foo", [1, 6]],
     #   [:params, nil, nil, nil, nil, nil, nil, nil],
     #   [:bodystmt, [[:void_stmt]], nil, nil, nil]]
+    #
+    # OR For endless methods
+    # [:def,
+    #   [:@ident, "foo", [1, 6]],
+    #   nil,
+    #   [:string_literal, [:string_content, [:@tstring_content, "bar", [1, 11]
+
     _, name, params, body = node
 
     consume_keyword "def"
@@ -2073,6 +2080,8 @@ class Rufo::Formatter
         end
         write ")"
         next_token
+        skip_space
+        format_endless_method if current_token_kind == :on_op
       end
     elsif !empty_params?(params)
       if parens_in_def == :yes
@@ -2085,13 +2094,17 @@ class Rufo::Formatter
       write ")" if parens_in_def == :yes
       skip_space
     elsif current_token_kind == :on_op
-      consume_space
-      consume_op "="
-      consume_space
-      skip_space
+      format_endless_method
     end
 
     visit body
+  end
+
+  def format_endless_method
+    consume_space
+    consume_op "="
+    consume_space
+    skip_space
   end
 
   def empty_params?(node)

--- a/lib/rufo/formatter.rb
+++ b/lib/rufo/formatter.rb
@@ -2032,6 +2032,7 @@ class Rufo::Formatter
   def visit_def_from_name(name, params, body)
     visit name
 
+    params = [] if params.nil?
     params = params[1] if params[0] == :paren
 
     skip_space
@@ -2082,6 +2083,11 @@ class Rufo::Formatter
 
       visit params
       write ")" if parens_in_def == :yes
+      skip_space
+    elsif current_token_kind == :on_op
+      consume_space
+      consume_op "="
+      consume_space
       skip_space
     end
 

--- a/spec/lib/rufo/formatter_source_specs/3.0/endless_methods.rb.spec
+++ b/spec/lib/rufo/formatter_source_specs/3.0/endless_methods.rb.spec
@@ -1,0 +1,5 @@
+#~# ORIGINAL format_endless_method
+def foo =    "a"
+
+#~# EXPECTED
+def foo = "a"

--- a/spec/lib/rufo/formatter_source_specs/3.0/endless_methods.rb.spec
+++ b/spec/lib/rufo/formatter_source_specs/3.0/endless_methods.rb.spec
@@ -3,3 +3,9 @@ def foo =    "a"
 
 #~# EXPECTED
 def foo = "a"
+
+#~# ORIGINAL format_endless_method_with_params
+def foo( a,     b) = "a"
+
+#~# EXPECTED
+def foo(a, b) = "a"


### PR DESCRIPTION
As of Ruby 3.0, support was added for endless methods, which offer some nice syntatic sugar by reducing a bit of boilerplate code.

https://rubyreferences.github.io/rubychanges/3.0.html#endless-method-definition

This PR adds support for formatting these in rufo as it was throwing errors for methods defined with and without params.

<!--
  Thank you for contributing to rufo!
  Please remember to update the CHANGELOG with the contents of this PR.
-->